### PR TITLE
Make the Exception classes available from zdesk

### DIFF
--- a/zdesk/__init__.py
+++ b/zdesk/__init__.py
@@ -1,2 +1,1 @@
-from .zdesk import Zendesk, get_id_from_url
-from .zdesk import ZendeskError, AuthenticationError, RateLimitError
+from .zdesk import *

--- a/zdesk/__init__.py
+++ b/zdesk/__init__.py
@@ -1,1 +1,2 @@
 from .zdesk import Zendesk, get_id_from_url
+from .zdesk import ZendeskError, AuthenticationError, RateLimitError


### PR DESCRIPTION
- update the init file for zdesk to make exception class available. this way we can catch specific exceptions, e.g. the `RateLimitError` 