### PR TITLE
Batch

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@
 * Matthew Jaskula (Generic parameter passing)
 * Tim Allard (HTTP return code checking)
 * Daniel Inniss (Porting work to `requests`)
+* Dominik Miedziński (Booksy International Sp. z o. o.)
 
 ## zendesk and zdesk 1.x
 


### PR DESCRIPTION
This helps with doing bulk requests to Zendesk. Instead of manually dealing with splitting requests, you can use batch function.
In the future, it'd be the best to properly support bulk requests like `Zendesk.organizations_update_many`, but it can get quite messy because of automatically generated library. At this moment I'm quite happy with this solution.