### PR TITLE
Check that our response is json before we attempt to parse as json

### DIFF
--- a/zdesk/zdesk.py
+++ b/zdesk/zdesk.py
@@ -228,7 +228,7 @@ class Zendesk(ZendeskAPI):
                     raise ZendeskError(
                         response.content, response.status_code, response)
 
-            if response.content.strip():
+            if response.content.strip() and 'json' in response.headers['content-type']:
                 content = response.json()
 
                 # set url to the next page if that was returned in the response


### PR DESCRIPTION
By making this change this allows for smoother integration of requesting items that still use the ZenDesk auth but are not strictly related to the API, such as attachments.