### PR TITLE
Fix Python 2.6 compat issue

### DIFF
--- a/tests/tickets/test_tickets.py
+++ b/tests/tickets/test_tickets.py
@@ -19,7 +19,7 @@ def test_ticket_ops(zd):
     # get id from url
     ticket_id = get_id_from_url(result)
 
-    assert(ticket_id.isdecimal(),
+    assert(ticket_id.isdigit(),
         'Returned created ticket ID is not a string of decimal digits')
 
     # show

--- a/tests/zdesk_common.py
+++ b/tests/zdesk_common.py
@@ -2,4 +2,4 @@ def islocation(s):
     return isinstance(s, str) and s.startswith('http') and s.endswith('.json')
 
 def isstatuscode(s):
-    return isinstance(s, str) and s.isdecimal() and len(s) == 3
+    return isinstance(s, str) and s.isdigit() and len(s) == 3

--- a/zdesk/zdesk.py
+++ b/zdesk/zdesk.py
@@ -4,15 +4,15 @@ import inspect
 import sys
 import time
 
-if sys.version_info.major < 3:
+import requests
+import six
+
+if six.PY2:
     from httplib import responses
     from urlparse import urlsplit
 else:
     from http.client import responses
     from urllib.parse import urlsplit
-
-import requests
-import six
 
 from .zdesk_api import ZendeskAPI
 
@@ -195,7 +195,7 @@ class Zendesk(ZendeskAPI):
             self._retry_on = set(value)
         else:
             _validate(value)
-            self._retry_on = {value}
+            self._retry_on = set([value])
 
     @retry_on.deleter
     def retry_on(self):


### PR DESCRIPTION
Everything else in zdesk works on Python 2.6, but using `.major` means it excepts on import. This fixes that, without breaking Python 3 compatibility.