### PR TITLE
Updated README to fix error in getting upload token from response

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ following code has worked well with zdesk scripts:
     response = zd.upload_create(filename=fname,
             data=fdata, mime_type=mime_type, complete_response=True)
 
-    upload_token = response['content']['upload']['token']
+    response_json = response['response'].json()
+    upload_token = response_json['upload']['token']
 
 ## Multipart file uploads (Help Center attachments)
 


### PR DESCRIPTION
`response['content']` returns bytes, rather than a dict. `response['response']` is the requests `Response` object where we can grab the response data in dict format with the `json()` method.
